### PR TITLE
fix: open Things URLs in background

### DIFF
--- a/packages/daemon/src/things.ts
+++ b/packages/daemon/src/things.ts
@@ -124,7 +124,8 @@ export function createTodo(projectName: string, todo: {
 
   // URLSearchParams encodes spaces as '+', but Things expects '%20'
   const url = `things:///add?${params.toString().replace(/\+/g, '%20')}`;
-  execSync(`open "${url}"`);
+  // -g flag opens in background without stealing focus
+  execSync(`open -g "${url}"`);
 }
 
 /**
@@ -149,7 +150,8 @@ export function updateTodo(authToken: string, thingsId: string, updates: {
 
   // URLSearchParams encodes spaces as '+', but Things expects '%20'
   const url = `things:///update?${params.toString().replace(/\+/g, '%20')}`;
-  execSync(`open "${url}"`);
+  // -g flag opens in background without stealing focus
+  execSync(`open -g "${url}"`);
 }
 
 /**


### PR DESCRIPTION
## Problem

Things app kommt bei jedem Sync in den Vordergrund, was störend ist wenn man in einer anderen App arbeitet.

## Ursache

`open "${url}"` bringt die Ziel-App in den Vordergrund.

## Lösung

`open -g "${url}"` - das `-g` Flag öffnet im Hintergrund ohne Focus zu stehlen.

## Geänderte Stellen

- `createTodo()` - Zeile 128
- `updateTodo()` - Zeile 154