### PR TITLE
ci: add GitHub Actions workflow for npm publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,78 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Dry run (build but don't publish)"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  id-token: write # Required for npm OIDC trusted publishing
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+          cache: "pnpm"
+
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
+
+      - name: Verify npm version (requires >= 11.5.1 for OIDC)
+        run: |
+          NPM_VERSION=$(npm --version)
+          echo "npm version: $NPM_VERSION"
+          # Simple version check using Node.js built-ins
+          node -e "
+            const [major, minor, patch] = '$NPM_VERSION'.split('.').map(Number);
+            const required = [11, 5, 1];
+            const ok = major > required[0] ||
+                       (major === required[0] && minor > required[1]) ||
+                       (major === required[0] && minor === required[1] && patch >= required[2]);
+            if (!ok) { console.error('npm >= 11.5.1 required for OIDC'); process.exit(1); }
+            console.log('npm version OK for OIDC');
+          "
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm build
+
+      # pnpm publish delegates to npm under the hood, so OIDC works automatically
+      # See: https://github.com/pnpm/pnpm/issues/9812
+      - name: Publish shared-things-daemon
+        if: ${{ !inputs.dry-run }}
+        run: pnpm --filter shared-things-daemon publish --no-git-checks --access public
+
+      - name: Publish shared-things-server
+        if: ${{ !inputs.dry-run }}
+        run: pnpm --filter shared-things-server publish --no-git-checks --access public
+
+      - name: Dry run summary
+        if: ${{ inputs.dry-run }}
+        run: |
+          echo "🧪 DRY RUN - No packages were published"
+          echo ""
+          echo "Packages that would be published:"
+          echo "  - shared-things-daemon@$(node -p "require('./packages/daemon/package.json').version")"
+          echo "  - shared-things-server@$(node -p "require('./packages/server/package.json').version")"
+          echo ""
+          echo "To publish for real, create a GitHub Release or run without dry-run"

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 *.sqlite
 .DS_Store
 *.tgz
+DEPLOY.md


### PR DESCRIPTION
## Summary
- Add CD pipeline for automatic npm publishing using OIDC trusted publishing
- Triggers on GitHub Release publication (+ manual workflow_dispatch)
- No npm tokens required - uses OpenID Connect authentication

## Changes
- `.github/workflows/publish.yml` - New workflow file (59 lines)

## How it works
1. Create a GitHub Release → workflow triggers
2. Builds all packages with pnpm
3. Publishes `shared-things-daemon` and `shared-things-server` to npm
4. OIDC handles authentication automatically

## After merging: One-time setup required

Configure trusted publisher on npmjs.com for both packages:

1. Go to https://www.npmjs.com/package/shared-things-daemon/access
2. Click "Trusted Publisher" → "GitHub Actions"
3. Fill in:
   - **Organization/user**: `yungweng`
   - **Repository**: `shared-things`
   - **Workflow filename**: `publish.yml`
   - **Environment**: *(leave empty)*
4. Repeat for https://www.npmjs.com/package/shared-things-server/access

## Release workflow after setup

```bash
# Bump versions
pnpm --filter shared-things-daemon exec npm version patch
pnpm --filter shared-things-server exec npm version patch

# Commit and push
git add -A && git commit -m "chore: bump to vX.Y.Z" && git push

# Create release (triggers publish)
gh release create vX.Y.Z --generate-notes
```

Closes #11