### PR TITLE
feat(server): add version display and update notifications

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -47,7 +47,8 @@
     "better-sqlite3": "^11.0.0",
     "chalk": "^5.6.2",
     "commander": "^12.0.0",
-    "fastify": "^4.26.0"
+    "fastify": "^4.26.0",
+    "update-notifier": "^7.0.0"
   },
   "devDependencies": {
     "@shared-things/common": "workspace:*",

--- a/packages/server/src/types/update-notifier.d.ts
+++ b/packages/server/src/types/update-notifier.d.ts
@@ -1,0 +1,33 @@
+declare module 'update-notifier' {
+  interface Package {
+    name: string;
+    version: string;
+  }
+
+  interface UpdateInfo {
+    latest: string;
+    current: string;
+    type: string;
+    name: string;
+  }
+
+  interface NotifierConfig {
+    get(key: string): unknown;
+    set(key: string, value: unknown): void;
+    delete(key: string): void;
+  }
+
+  interface UpdateNotifier {
+    update?: UpdateInfo;
+    config?: NotifierConfig;
+    fetchInfo(): Promise<UpdateInfo>;
+    notify(options?: object): void;
+  }
+
+  interface Options {
+    pkg: Package;
+    updateCheckInterval?: number;
+  }
+
+  export default function updateNotifier(options: Options): UpdateNotifier;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       fastify:
         specifier: ^4.26.0
         version: 4.29.1
+      update-notifier:
+        specifier: ^7.0.0
+        version: 7.3.1
     devDependencies:
       '@shared-things/common':
         specifier: workspace:*


### PR DESCRIPTION
## Summary
- Show current version in `status` command
- Add update-notifier to check for newer versions  
- Display update availability inline

## Changes
```
📊 Server Status

  Version: 1.0.5
  Version: 1.0.5 → 1.0.6 available  ← when update exists
  Status:  ● running
  PID:     12345
  ...
```

Also shows update notice on CLI exit (same as daemon).

## Test plan
- [x] Build succeeds
- [x] `shared-things-server status` shows version
- [x] Verify update notification appears when new version exists